### PR TITLE
Fix flake8 violations

### DIFF
--- a/filmfest/settings/dev.py
+++ b/filmfest/settings/dev.py
@@ -3,8 +3,8 @@ from .base import *  # noqa
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
-DJANGO_TEMPLATES['OPTIONS']['debug'] = True
-INSTALLED_APPS.append('debug_toolbar')
+DJANGO_TEMPLATES['OPTIONS']['debug'] = True  # noqa: F405
+INSTALLED_APPS.append('debug_toolbar')  # noqa: F405
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = '=bi%8p-j&&y5%4h8^oq-%(b@p&&wyu72b7qk4dlyvwo)!)wn20'

--- a/filmfest/settings/prod.py
+++ b/filmfest/settings/prod.py
@@ -13,7 +13,7 @@ DATABASES = {
 
 DEBUG = False
 TEMPLATE_DEBUG = False
-SECRET_KEY = os.environ['DJANGO_SECRET_KEY']
+SECRET_KEY = os.environ['DJANGO_SECRET_KEY']  # noqa: F405
 ALLOWED_HOSTS = ['next.filmfest.by']
 
 LOGGING = {
@@ -27,7 +27,7 @@ LOGGING = {
     'loggers': {
         'django': {
             'handlers': ['console'],
-            'level': os.getenv('DJANGO_LOG_LEVEL', 'INFO'),
+            'level': os.getenv('DJANGO_LOG_LEVEL', 'INFO'),  # noqa: F405
         },
     },
 }

--- a/filmfest/settings/pytest.py
+++ b/filmfest/settings/pytest.py
@@ -7,7 +7,7 @@ SECRET_KEY = 'test'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'test_db.sqlite3'),
+        'NAME': os.path.join(BASE_DIR, 'test_db.sqlite3'),  # noqa: F405
     }
 }
 

--- a/results/migrations/0013_update_related_facts_name.py
+++ b/results/migrations/0013_update_related_facts_name.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import migrations, models
+from django.db import migrations
 import modelcluster.fields
 
 
@@ -15,6 +15,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='resultsfact',
             name='page',
-            field=modelcluster.fields.ParentalKey(related_name='related_facts', to='results.ResultsPage'),
+            field=modelcluster.fields.ParentalKey(related_name='related_facts',
+                                                  to='results.ResultsPage'),
         ),
     ]


### PR DESCRIPTION
This fixes significant flake8 violations in 0013_update_related_facts_name.py and ignores F405 in other files.

F405 is caused by the way we combine modules using `import *`
