### PR TITLE
Upgrade Django==1.9.8 and wagtail==1.5.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM fedora:22
+FROM fedora:24
 MAINTAINER Stas Rudakou "stas@garage22.net"
 
 RUN dnf -y update; dnf clean all;
-RUN dnf -y install python python-virtualenv gcc postgresql-devel libjpeg-devel zlib-devel mailcap
+RUN dnf -y install python python-virtualenv gcc postgresql-devel libjpeg-devel zlib-devel mailcap redhat-rpm-config
 
 ENV PYTHONUNBUFFERED 1
 

--- a/cpm_generic/migration_utils.py
+++ b/cpm_generic/migration_utils.py
@@ -20,3 +20,31 @@ def get_content_type(apps, app_label, model):
         app_label=app_label
     )
     return content_type
+
+
+def get_image_model(apps):
+    """ Return Image model that works in migrations.
+
+    Models created by Django migration subsystem contain fields,
+    but dont' contain methods of the original models.
+
+    The hack with adding method get_upload_to lets us save images in
+    migrations, e.g.:
+    >>> from django.core.files import File
+    >>> Image = get_image_model()
+    >>> photo = Image(title='example title')
+    >>> with open(path) as f:
+    ...     photo.file.save(name='name.png', content=File(f))
+
+    Args:
+        apps (django.db.migrations.state.StateApps): Apps registry.
+
+    Returns:
+        type: Image model.
+    """
+    from wagtail.wagtailimages.models import Image as LatestImage
+
+    Image = apps.get_model('wagtailimages.Image')
+    Image.get_upload_to = LatestImage.get_upload_to.im_func
+
+    return Image

--- a/filmfest/settings/base.py
+++ b/filmfest/settings/base.py
@@ -33,7 +33,6 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
 
     'taggit',
-    'compressor',
     'modelcluster',
 
     'wagtail.wagtailcore',
@@ -128,7 +127,6 @@ USE_TZ = True
 STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
-    'compressor.finders.CompressorFinder',
 )
 
 STATICFILES_DIRS = (

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
-Django==1.8.7
-wagtail==1.2
+Django==1.9.8
+wagtail==1.5.2
 psycopg2>=2,<3
 pycountry==0.14.2
 elasticsearch==2.1.0

--- a/results/migrations/0001_initial.py
+++ b/results/migrations/0001_initial.py
@@ -8,7 +8,7 @@ import django.db.models.deletion
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('wagtailimages', '0008_image_created_at_index'),
+        ('wagtailimages', '0010_change_on_delete_behaviour'),
         ('wagtailcore', '0019_verbose_names_cleanup'),
     ]
 

--- a/results/migrations/0005_add_jury_data.py
+++ b/results/migrations/0005_add_jury_data.py
@@ -7,7 +7,8 @@ from django.core.files import File
 from django.db import migrations
 from django.utils.text import slugify
 
-from cpm_generic.migration_utils import add_subpage, get_content_type
+from cpm_generic.migration_utils import (add_subpage, get_content_type,
+                                         get_image_model)
 
 
 def get_data():
@@ -207,7 +208,7 @@ def get_data():
 
 def add_jury_member_pages(apps, schema_editor):
     HomePage = apps.get_model('home.HomePage')
-    Image = apps.get_model('wagtailimages.Image')
+    Image = get_image_model(apps)
     IndexPage = apps.get_model('cpm_generic.IndexPage')
     JuryMemberPage = apps.get_model("results.JuryMemberPage")
 

--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -5,7 +5,7 @@ import pytest
 def test_locale_redirect(client):
     response = client.get('/')
     assert response.status_code == 302
-    assert response['Location'] == 'http://testserver/en/'
+    assert response['Location'] == '/en/'
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Some notes:
- In order to do that I had to start using fedora:24 in Dockerfile.
- We also get rid of compressor as suggested by wagtail release notes.
- One migration that saves images was fixed by hacking migrations Image
  model.
- Acceptance redirect test was fixed by getting rid of testsever prefix.
