### PR TITLE
Fix RemovedInDjango110Warning for search

### DIFF
--- a/filmfest/urls.py
+++ b/filmfest/urls.py
@@ -6,12 +6,13 @@ from django.contrib import admin
 from wagtail.wagtailadmin import urls as wagtailadmin_urls
 from wagtail.wagtailcore import urls as wagtail_urls
 
+import search.views
 
 urlpatterns = [
     url(r'^django-admin/', include(admin.site.urls)),
     url(r'^admin/', include(wagtailadmin_urls)),
 ] + i18n_patterns('',
-    url(r'^search/$', 'search.views.search', name='search'),  # noqa
+    url(r'^search/$', search.views.search, name='search'),
     url(r'', include(wagtail_urls)),
 )
 

--- a/filmfest/urls.py
+++ b/filmfest/urls.py
@@ -11,7 +11,8 @@ import search.views
 urlpatterns = [
     url(r'^django-admin/', include(admin.site.urls)),
     url(r'^admin/', include(wagtailadmin_urls)),
-] + i18n_patterns('',
+] + i18n_patterns(
+    '',
     url(r'^search/$', search.views.search, name='search'),
     url(r'', include(wagtail_urls)),
 )


### PR DESCRIPTION
Support for string view arguments to url() is deprecated and will
be removed in Django 1.10 (got search.views.search). Pass the
callable instead.
