### PR TITLE
Install package postgresql in web container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM fedora:24
 MAINTAINER Stas Rudakou "stas@garage22.net"
 
 RUN dnf -y update; dnf clean all;
-RUN dnf -y install python python-virtualenv gcc postgresql-devel libjpeg-devel zlib-devel mailcap redhat-rpm-config
+RUN dnf -y install python python-virtualenv gcc postgresql postgresql-devel libjpeg-devel zlib-devel mailcap redhat-rpm-config
 
 ENV PYTHONUNBUFFERED 1
 


### PR DESCRIPTION
This fixes the problem below after launching `docker-compose run web dbshell`:

```
CommandError: You appear not to have the 'psql' program installed or on
your path.
```

This also requires one to rebuild docker image with (restart of running
services isn't required):

```
docker-compose build web
```
