### PR TITLE
Fix deprecation warnings:

### DIFF
--- a/filmfest/urls.py
+++ b/filmfest/urls.py
@@ -16,7 +16,6 @@ urlpatterns = [
     url(r'^admin/', include(wagtailadmin_urls)),
     url(r'^api/v2/', api.v2.urls),
 ] + i18n_patterns(
-    '',
     url(r'^search/$', search.views.search, name='search'),
     url(r'', include(wagtail_urls)),
 )


### PR DESCRIPTION
next.filmfest.by\filmfest\urls.py:21:
RemovedInDjango110Warning: Calling i18n_patterns() with the `prefix`
argument and with tuples instead of
django.conf.urls.url() instances is deprecated and will no longer work in
Django 1.10. Use a list of django.conf.urls.url() instances instead.
  url(r'', include(wagtail_urls)),

site-packages\django\conf\urls\i18n.py:25:
RemovedInDjango110Warning: django.conf.urls.patterns() is deprecated and
will be removed in Django 1.10. Update your urlpatterns to be a list of
django.conf.urls.url() instances instead.
  pattern_list = patterns(prefix, *args)
