### PR TITLE
Open photo in binary mode to fix migrations on Windows

### DIFF
--- a/results/migrations/0005_add_jury_data.py
+++ b/results/migrations/0005_add_jury_data.py
@@ -70,7 +70,7 @@ def add_jury_member_pages(apps, schema_editor):
 
     for item in _get_data():
         photo = Image(title=item['title'], collection=collection_id)
-        with open(_get_photo_path(item['photo'])) as photo_file:
+        with open(_get_photo_path(item['photo']), 'rb') as photo_file:
             photo.file.save(name=item['photo'], content=File(photo_file))
             photo.save()
 

--- a/results/migrations/0016_add_results_14_data.py
+++ b/results/migrations/0016_add_results_14_data.py
@@ -41,7 +41,7 @@ def add_jury_member_pages(apps, schema_editor):
         photo_file = os.path.join(MIGRATION_DIR, item['photo'])
         photo.file.save(
             name=item['title'] + os.extsep + item['photo_ext'],
-            content=File(open(photo_file, 'r'))
+            content=File(open(photo_file, 'rb'))
         )
         photo.save()
 


### PR DESCRIPTION
Windows converts unix linefeeds to CRLF, which results
in broken images, which results in failure to get their
size, which results in

```
django.db.utils.IntegrityError: NOT NULL constraint failed: wagtailimages_image.width
```
