### PR TITLE
Enable wagtailstyleguide app on dev machines

### DIFF
--- a/filmfest/settings/dev.py
+++ b/filmfest/settings/dev.py
@@ -12,6 +12,9 @@ SECRET_KEY = '=bi%8p-j&&y5%4h8^oq-%(b@p&&wyu72b7qk4dlyvwo)!)wn20'
 
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
+# Enables /admin/styleguide/ route (Menu -> Settings -> Styleguide)
+INSTALLED_APPS.append('wagtail.contrib.wagtailstyleguide')  # noqa: F405
+
 
 try:
     from .local import *  # noqa


### PR DESCRIPTION
This enables `/admin/styleguide/` route (Menu -> Settings -> Styleguide)

![styleguide](https://cloud.githubusercontent.com/assets/382950/21076776/2b4b8a12-bf45-11e6-9b40-f974a0cd3ec4.png)

I found this styleguide very useful for looking up icon names:

![icons](https://cloud.githubusercontent.com/assets/382950/21076779/45a78f32-bf45-11e6-95e1-0c8cb4b6f627.png)
