### PR TITLE
Add support for static site previews with Netlify

### DIFF
--- a/filmfest/settings/netlify.py
+++ b/filmfest/settings/netlify.py
@@ -1,0 +1,4 @@
+from .base import *  # noqa
+
+SECRET_KEY = 'statickey'
+ALLOWED_HOSTS = ['127.0.0.1']

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,7 +2,6 @@
 elasticsearch==2.1.0
 Django==1.9.8
 djangorestframework==3.4.0
-psycopg2==2.6.2
 pycountry==0.14.2
 wagtail==1.6rc1
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,6 @@
 # consciously added packages
 -r base.txt
+
 django-debug-toolbar==1.5
 tox==2.3.1
 

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,1 +1,2 @@
 -r base.txt
+psycopg2==2.6.2

--- a/requirements/pytest.txt
+++ b/requirements/pytest.txt
@@ -1,5 +1,7 @@
 # consciously added packages
 -r base.txt
+psycopg2==2.6.2
+
 flake8-debugger==1.4.0
 flake8-print==2.0.2
 pytest==2.9.2

--- a/scripts/netlify.sh
+++ b/scripts/netlify.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# Helper script to create web site previews on Netlify.
+
+# It bootstraps Django to create static copy of website
+# content and grabs it with wget.
+#
+# Produces `wget.log.txt` that can be downloaded for
+# troubleshooting. Uses custom settings in 
+# ../filmfest/settings/netlify.py
+#
+# Script should complete in 15 minutes.
+#
+
+ROOTDIR=$(dirname $(dirname $0))
+cd $ROOTDIR
+
+echo --- [bootstrap] creating virtualenv in .v
+virtualenv .v
+.v/bin/pip install -r requirements/base.txt
+
+echo --- [bootstrap] running migrations
+# switch back from dev config to base
+export DJANGO_SETTINGS_MODULE=filmfest.settings.netlify
+export PYTHONUNBUFFERED=1
+.v/bin/python manage.py migrate
+
+echo --- [bootstrap] starting server in background
+.v/bin/python manage.py runserver 127.0.0.1:8000 --insecure &
+sleep 5
+
+echo --- [bootstrap] grabbing site copy
+mkdir public
+cd public
+wget -m http://127.0.0.1:8000 --no-host-directories 2>&1 | tee wget.log.txt
+pwd
+ls -la
+ps aux
+
+echo --- [bootstrap] stopping server
+pkill -f manage.py
+
+# returns 0, but we can also check wget exit code or
+# log for 404 errors to fail build if there are any
+
+exit 0


### PR DESCRIPTION
This is squashed https://github.com/kinaklub/next.filmfest.by/pull/84 ready to review.

* Netlify build system has no PostgreSQL
* PostgreSQL is not used for development (it gets SQLite)
* PostgreSQL is still needed to run tests
* Run Django in background, wait 5 seconds for it to start,
  then wget contents recursively and pkill manage.py
* Django is executed with own server in --insecure mode to
  serve static resources (images, css etc.) that are
  normally only served in development DEBUG mode
* Custom DJANGO settings is needed to setup security for
  successful server start - SECRET_KEY and list of domains
  served
* Directory to put downloaded .html contents and serve web
  site is configured through Netlify website - and it is
  public/ in project root
* Netlify allows some customization with netlify.toml, but
  it is not used here
* wget messages are saved in wget.log.txt and uploaded too
* Need to enable unbuffered Python output to see messages
  in Netlify when for some reason the process hangs
* Force exit 0 to upload content regardless of 404 errors.
  This may need to be changed in future, but for now it
  may break other PRs, which is not good.