### PR TITLE
Use the same Dockerfile with different requirements for dev and production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM fedora:24
 MAINTAINER Stas Rudakou "stas@garage22.net"
 
+ARG requirements=prod.txt
+
 RUN dnf -y update; dnf clean all;
 RUN dnf -y install python python-virtualenv gcc postgresql postgresql-devel libjpeg-devel zlib-devel mailcap redhat-rpm-config
 
@@ -14,7 +16,7 @@ WORKDIR /app/src
 
 ADD . /app/src/
 ADD IMAGE_VERSION /app/IMAGE_VERSION
-RUN /app/bin/pip install -r requirements/dev.txt
+RUN /app/bin/pip install -r "requirements/$requirements"
 
 ENV DJANGO_SETTINGS_MODULE filmfest.settings.docker
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,10 @@ services:
   elasticsearch:
     image: elasticsearch:1.7.3
   web:
-    build: .
+    build:
+      context: .
+      args:
+        requirements: dev_pg.txt
     command: runserver 0.0.0.0:8000
     volumes:
       - .:/app/src

--- a/requirements/dev_pg.txt
+++ b/requirements/dev_pg.txt
@@ -1,0 +1,2 @@
+-r dev.txt
+psycopg2==2.6.2


### PR DESCRIPTION
Also psycopg2 was removed from `requirements/dev.txt` some days ago
which broke the Docker image. I'm adding `dev_pg.txt` to fix it. We'll
add some tests for this case soon.