### PR TITLE
Improve the situation with versioning of 3rd party tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: python
 sudo: false
+dist: trusty
 python:
   - "2.7"
 addons:
-  postgresql: "9.4"
+  postgresql: "9.6"
 services:
   - postgresql
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ addons:
 services:
   - postgresql
 install:
-  - pip install tox demjson
+  - pip install tox==2.3.2 demjson==2.2.4
 before_script:
   - psql -c 'create database filmfest;' -U postgres
 script:

--- a/README.md
+++ b/README.md
@@ -123,8 +123,6 @@ PR review process:
 4. Create a local user:
 
     ```
-    docker-compose run web update_index
-
     docker-compose run web createsuperuser
     ```
 

--- a/README.md
+++ b/README.md
@@ -120,11 +120,9 @@ PR review process:
 
 4. Give postgres 20-30 seconds to initialize
 
-4. DB provisioning (should be performed only once from another terminal):
+4. Create a local user:
 
     ```
-    docker-compose run web migrate
-
     docker-compose run web update_index
 
     docker-compose run web createsuperuser

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     volumes:
       - postgres96:/var/lib/postgresql
   elasticsearch:
-    image: elasticsearch:1.7.3
+    image: elasticsearch:1.7.6
   web:
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 version: "2"
 services:
   db:
-    image: postgres:latest
+    image: postgres:9.6.1
     ports:
       - "5433:5432"
     volumes:
-      - db:/var/lib/postgresql
+      - postgres96:/var/lib/postgresql
   elasticsearch:
     image: elasticsearch:1.7.3
   web:
@@ -24,5 +24,5 @@ services:
     ports:
       - "8000:8000"
 volumes:
-  db:
+  postgres96:
     driver: local

--- a/manage.py
+++ b/manage.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import os
 import sys
+import time
 
 
 def test(args, settings_module):
@@ -15,10 +16,31 @@ def bash(args, settings_module):
     sys.exit(call('/usr/bin/bash', *args))
 
 
+def _wait_for_db(sleep_interval=2, max_wait=600):
+    """Wait for DB container to start"""
+    from django.db import connections
+    from django.db.utils import OperationalError
+
+    t0 = time.time()
+    while True:
+        try:
+            connections['default'].cursor()
+        except OperationalError:
+            if time.time() - t0 > max_wait:
+                raise
+            else:
+                print "Waiting for DB initialization"
+                time.sleep(sleep_interval)
+        else:
+            break
+
+
 def launch(args, settings_module):
     """Launch the application"""
     from django.conf import settings
     from django.core.management import execute_from_command_line
+
+    _wait_for_db()
     execute_from_command_line(['manage.py', 'migrate', '--noinput'])
 
     http_socket = (args[:1] + [':8000'])[0]

--- a/manage.py
+++ b/manage.py
@@ -42,6 +42,7 @@ def launch(args, settings_module):
 
     _wait_for_db()
     execute_from_command_line(['manage.py', 'migrate', '--noinput'])
+    execute_from_command_line(['manage.py', 'update_index'])
 
     http_socket = (args[:1] + [':8000'])[0]
     uwsgi_args = [


### PR DESCRIPTION
* Remove inconsistencies between dev and test environments
* Update postgres and elasticsearch to the latest available versions
* Fix versions of 3rd party python tools used in .travis.yml

Add some automation to `manage.py launch` so it will be easier for developers to update their environments once this is merged.

Warning: local databases will be cleared once this is merged (the old data will still be manually accessible via docker volume `{{folder_name}}_db`).