### PR TITLE
Replace scripts/jsoncheck.py with pytest-jsonlint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,8 @@ addons:
 services:
   - postgresql
 install:
-  - pip install tox==2.3.2 demjson==2.2.4
+  - pip install tox==2.3.2
 before_script:
   - psql -c 'create database filmfest;' -U postgres
 script:
-  - scripts/jsoncheck.py
   - tox -e "py27-{sqlite,pg}"

--- a/requirements/_pytest.txt
+++ b/requirements/_pytest.txt
@@ -3,10 +3,12 @@ flake8-debugger==1.4.0
 flake8-print==2.0.2
 pytest==2.9.2
 pytest-django==2.9.1
+pytest-jsonlint==0.0.1
 pytest-flake8==0.6
 
 # dependencies
 configparser==3.5.0
+demjson==2.2.4
 enum34==1.1.6
 flake8==3.0.2
 flake8-debugger==1.4.0


### PR DESCRIPTION
[pytest-jsonlint](https://github.com/keis/pytest-jsonlint) plugin is based on demjson - just like `scripts/jsoncheck.py`.

This plugin will check all the json files as a part of tox/pytest execution. That means we'll need to remember less commands to be able to check the code before pushing.