### PR TITLE
Production stack improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,15 @@ addons:
 services:
   - postgresql
   - docker
-before_install:
-  - sudo apt-get update
-  - sudo apt-get install docker-engine
 install:
   - pip install tox==2.3.2
 before_script:
   - psql -c 'create database filmfest;' -U postgres
 script:
   - tox -e "py27-{sqlite,pg}"
+before_deploy:
+  - sudo apt-get update
+  - sudo apt-get install docker-engine
 deploy:
   - provider: script
     script: ./scripts/push_image.sh

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -18,7 +18,12 @@ services:
     environment:
       STACK_PREFIX: next_
     deploy:
-      replicas: 1
+      replicas: 2
+      update_config:
+        parallelism: 1
+        delay: 30s
+        monitor: 20s
+        failure_action: pause
   haproxy:
     image: kinaklub/filmfest-haproxy:0.2
     ports:

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -20,7 +20,7 @@ services:
     deploy:
       replicas: 1
   haproxy:
-    image: kinaklub/filmfest-haproxy:0.1
+    image: kinaklub/filmfest-haproxy:0.2
     ports:
       - "80:80"
     environment:


### PR DESCRIPTION
This PR switches to haproxy image 0.2 - version 0.1 used to disable server forever on problems with domain name resolution (which usually happened during deploys).

We also improve update config to make sure updates doesn't cause downtimes in normal mode.