### PR TITLE
Enable py-autoreload in debug mode

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -56,7 +56,11 @@ def launch(args, settings_module):
         '--vacuum',
         '--static-map', '%s=%s' % (settings.MEDIA_URL, settings.MEDIA_ROOT),
     ]
-    if not settings.DEBUG:
+    if settings.DEBUG:
+        uwsgi_args.extend([
+            '--py-autoreload', '1',
+        ])
+    else:
         uwsgi_args.extend([
             '--static-map', '%s=%s' % (settings.STATIC_URL,
                                        settings.STATIC_ROOT)


### PR DESCRIPTION
`manage.py runserver` had autoreload (which is very convenient). We lost
autoreload when we switched to `uwsgi`, so let's add the feature back.