### PR TITLE
Various docker-stack.yml fixes

### DIFF
--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -17,6 +17,8 @@ services:
     command: launch
     environment:
       STACK_PREFIX: next_
+    volumes:
+      - web_media:/app/media
     deploy:
       replicas: 2
       update_config:
@@ -36,4 +38,6 @@ volumes:
   postgres96:
     driver: local
   elasticsearch17:
+    driver: local
+  web_media:
     driver: local

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -17,6 +17,7 @@ services:
     command: launch
     environment:
       STACK_PREFIX: next_
+      DJANGO_ALLOWED_HOSTS: "${DJANGO_ALLOWED_HOSTS:-next.filmfest.by}"
     volumes:
       - web_media:/app/media
     deploy:

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -18,6 +18,7 @@ services:
     environment:
       STACK_PREFIX: next_
       DJANGO_ALLOWED_HOSTS: "${DJANGO_ALLOWED_HOSTS:-next.filmfest.by}"
+      DJANGO_SECRET_KEY: "${DJANGO_SECRET_KEY:-secret}"
     volumes:
       - web_media:/app/media
     deploy:


### PR DESCRIPTION
This PR contains various fixes for `docker-stack.yml`

* [critical] Add a separate volume for media to `docker-stack.yml`

  Otherwise images get lost after container restart.

* [major] `docker-stack.yml` should take value of `DJANGO_SECRET_KEY` from env

  We should override SECRET_KEY in production. We'll do it by setting an env variable in Travis.

* [minor] `docker-stack.yml` should take value of `DJANGO_ALLOWED_HOSTS` from env

  This can help to test deployment using a local docker-machine.