### PR TITLE
Move serveral layers into a separate docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,7 @@
-FROM fedora:24
+FROM kinaklub/filmfest-base:1.0
 MAINTAINER Stas Rudakou "stas@garage22.net"
 
 ARG requirements=prod.txt
-
-RUN dnf -y update && \
-    dnf -y install python python-virtualenv gcc postgresql postgresql-devel libjpeg-devel zlib-devel mailcap redhat-rpm-config && \
-    dnf clean all && \
-    rm -rf /var/cache/dnf
-
-ENV PYTHONUNBUFFERED 1
-
-RUN useradd -d /app -m filmfest
-USER filmfest
-RUN virtualenv /app
-RUN mkdir /app/src /app/media /app/static
-WORKDIR /app/src
 
 ADD . /app/src/
 ADD IMAGE_VERSION /app/IMAGE_VERSION


### PR DESCRIPTION
Let's move the layers that don't get updated often into a separate docker image: [kinaklub/filmfest-base](https://github.com/kinaklub/docker-filmfest-base)

`dnf` invocations don't usually get cached as they take a lot of files from network. On my machine with all the base images being cached I get the following results.

Before:
```
$ time docker build --no-cache --quiet .
sha256:19ea80fc4f47bc477154d941317c8260d15f4f006a2a87ed40a9b81ae13403c8
docker build --no-cache --quiet .  0.76s user 0.05s system 0% cpu 4:15.00 total
```

After:
```
$ time docker build --no-cache --quiet .
sha256:50bc0904499ad9111f5019241dc3bfa7b4487e3b5a924759f345abf47bcf50df
docker build --no-cache --quiet .  0.75s user 0.06s system 1% cpu 1:10.63 total
```