### PR TITLE
haproxy: use image kinaklub/filmfest-haproxy:0.3

### DIFF
--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -25,7 +25,7 @@ services:
         monitor: 20s
         failure_action: pause
   haproxy:
-    image: kinaklub/filmfest-haproxy:0.2
+    image: kinaklub/filmfest-haproxy:0.3
     ports:
       - "80:80"
     environment:


### PR DESCRIPTION
This will help to resolve the following issue:
    
* when a `haproxy` container is started and there is no `web`
  container running, haproxy just disables the backend because `libc`
  fails to resolve the address

Updates worked fine unless `haproxy` image was updated. Now we can also safely update `haproxy` image.