### PR TITLE
Fix edit link in GenericModelChooserPanel (fixes #89)

### DIFF
--- a/modeladminutils/edit_handlers.py
+++ b/modeladminutils/edit_handlers.py
@@ -12,10 +12,13 @@ class BaseGenericModelChooserPanel(BaseChooserPanel):
     object_type_name = 'item'
 
     _target_model = None
+    url_helper_class = None
 
     @classmethod
     def widget_overrides(cls):
-        return {cls.field_name: GenericModelChooser(model=cls.target_model())}
+        chooser = GenericModelChooser(model=cls.target_model(),
+                                      url_helper_class=cls.url_helper_class)
+        return {cls.field_name: chooser}
 
     @classmethod
     def target_model(cls):
@@ -34,8 +37,9 @@ class BaseGenericModelChooserPanel(BaseChooserPanel):
 
 
 class GenericModelChooserPanel(object):
-    def __init__(self, field_name):
+    def __init__(self, field_name, url_helper_class=None):
         self.field_name = field_name
+        self.url_helper_class = url_helper_class
 
     def bind_to_model(self, model):
         return type(
@@ -44,5 +48,6 @@ class GenericModelChooserPanel(object):
             {
                 'model': model,
                 'field_name': self.field_name,
+                'url_helper_class': self.url_helper_class,
             }
         )

--- a/modeladminutils/templates/modeladminutils/widgets/genericmodel_chooser.html
+++ b/modeladminutils/templates/modeladminutils/widgets/genericmodel_chooser.html
@@ -6,4 +6,4 @@
 <span class="title">{{ item }}</span>
 {% endblock %}
 
-{% block edit_chosen_item_url %}{% if item %}{% url 'wagtailsnippets:edit' model_opts.app_label model_opts.model_name item.id %}{% endif %}{% endblock %}
+{% block edit_chosen_item_url %}{{ edit_url }}{% endblock %}


### PR DESCRIPTION
This fixes #89 (Incorrect link to the jury member page from season edit)

![next89](https://cloud.githubusercontent.com/assets/382950/23091313/5ab4a508-f5c4-11e6-82a8-2844fc63ca25.png)
