### PR TITLE
Make sure media is stored in a volume on a dev environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       DJANGO_SETTINGS_MODULE: filmfest.settings.docker
     volumes:
       - .:/app/src
+      - web_media:/app/media
     links:
       - db:db
       - elasticsearch:elasticsearch
@@ -25,4 +26,6 @@ services:
       - "8000:8000"
 volumes:
   postgres96:
+    driver: local
+  web_media:
     driver: local


### PR DESCRIPTION
This was broken in 6fb29cbe while trying to fix the same issue in production.

The easiest way to fix an existing dev environment is to wipe database and relaunch migrations.