### PR TITLE
Rename GenericModelChooser into AdminModelChooser and fix some bugs

### DIFF
--- a/cpm_data/models.py
+++ b/cpm_data/models.py
@@ -9,7 +9,7 @@ from wagtail.wagtailcore.fields import RichTextField
 from wagtail.wagtailimages.edit_handlers import ImageChooserPanel
 from wagtail.wagtailsearch import index
 
-from modeladminutils.edit_handlers import GenericModelChooserPanel
+from modeladminutils.edit_handlers import AdminModelChooserPanel
 from cpm_generic.constants import COUNTRIES
 from cpm_generic.models import TranslatedField
 
@@ -193,7 +193,7 @@ class SeasonRelatedJuryMember(Orderable):
     country = property(lambda self: self.jury_member.country)
 
     panels = [
-        GenericModelChooserPanel('jury_member'),
+        AdminModelChooserPanel('jury_member'),
         FieldPanel('category_en'),
         FieldPanel('category_be'),
         FieldPanel('category_ru'),
@@ -242,7 +242,7 @@ class SeasonRelatedPartner(Orderable):
     image = property(lambda self: self.partner.image)
 
     panels = [
-        GenericModelChooserPanel('partner'),
+        AdminModelChooserPanel('partner'),
     ]
 
 

--- a/events/models.py
+++ b/events/models.py
@@ -8,7 +8,7 @@ from wagtail.wagtailcore.models import Orderable, Page
 from wagtail.wagtailadmin.edit_handlers import FieldPanel, InlinePanel
 
 from cpm_generic.models import TranslatedField
-from modeladminutils.edit_handlers import GenericModelChooserPanel
+from modeladminutils.edit_handlers import AdminModelChooserPanel
 from submissions.constants import SECTIONS
 
 
@@ -34,7 +34,7 @@ class FilmProgramRelatedFilm(Orderable):
     frame = property(lambda self: self.film.frame)
 
     panels = [
-        GenericModelChooserPanel('film'),
+        AdminModelChooserPanel('film'),
     ]
 
 

--- a/modeladminutils/admin_urls.py
+++ b/modeladminutils/admin_urls.py
@@ -3,7 +3,7 @@ from django.conf.urls import url
 from modeladminutils.views import chooser
 
 urlpatterns = [
-    url(r'^choose/$', chooser.choose, name='choose_generic'),
+    url(r'^choose/$', chooser.choose, name='choose_adminmodel'),
     url(r'^choose/(\w+)/(\w+)/$', chooser.choose, name='chooser'),
     url(r'^choose/(\w+)/(\w+)/(\d+)/$', chooser.chosen, name='chosen'),
 ]

--- a/modeladminutils/edit_handlers.py
+++ b/modeladminutils/edit_handlers.py
@@ -5,10 +5,10 @@ from django.utils.safestring import mark_safe
 
 from wagtail.wagtailadmin.edit_handlers import BaseChooserPanel
 
-from modeladminutils.widgets import GenericModelChooser
+from modeladminutils.widgets import AdminModelChooser
 
 
-class BaseGenericModelChooserPanel(BaseChooserPanel):
+class BaseAdminModelChooserPanel(BaseChooserPanel):
     object_type_name = 'item'
 
     _target_model = None
@@ -16,8 +16,8 @@ class BaseGenericModelChooserPanel(BaseChooserPanel):
 
     @classmethod
     def widget_overrides(cls):
-        chooser = GenericModelChooser(model=cls.target_model(),
-                                      url_helper_class=cls.url_helper_class)
+        chooser = AdminModelChooser(model=cls.target_model(),
+                                    url_helper_class=cls.url_helper_class)
         return {cls.field_name: chooser}
 
     @classmethod
@@ -36,15 +36,15 @@ class BaseGenericModelChooserPanel(BaseChooserPanel):
         }))
 
 
-class GenericModelChooserPanel(object):
+class AdminModelChooserPanel(object):
     def __init__(self, field_name, url_helper_class=None):
         self.field_name = field_name
         self.url_helper_class = url_helper_class
 
     def bind_to_model(self, model):
         return type(
-            str('_GenericModelChooserPanel'),
-            (BaseGenericModelChooserPanel,),
+            str('_AdminModelChooserPanel'),
+            (BaseAdminModelChooserPanel,),
             {
                 'model': model,
                 'field_name': self.field_name,

--- a/modeladminutils/edit_handlers.py
+++ b/modeladminutils/edit_handlers.py
@@ -12,12 +12,10 @@ class BaseAdminModelChooserPanel(BaseChooserPanel):
     object_type_name = 'item'
 
     _target_model = None
-    url_helper_class = None
 
     @classmethod
     def widget_overrides(cls):
-        chooser = AdminModelChooser(model=cls.target_model(),
-                                    url_helper_class=cls.url_helper_class)
+        chooser = AdminModelChooser(model=cls.target_model())
         return {cls.field_name: chooser}
 
     @classmethod
@@ -37,9 +35,8 @@ class BaseAdminModelChooserPanel(BaseChooserPanel):
 
 
 class AdminModelChooserPanel(object):
-    def __init__(self, field_name, url_helper_class=None):
+    def __init__(self, field_name):
         self.field_name = field_name
-        self.url_helper_class = url_helper_class
 
     def bind_to_model(self, model):
         return type(
@@ -48,6 +45,5 @@ class AdminModelChooserPanel(object):
             {
                 'model': model,
                 'field_name': self.field_name,
-                'url_helper_class': self.url_helper_class,
             }
         )

--- a/modeladminutils/helpers.py
+++ b/modeladminutils/helpers.py
@@ -1,0 +1,13 @@
+from django.core.urlresolvers import NoReverseMatch, reverse
+
+from wagtail.contrib.modeladmin.helpers import AdminURLHelper
+
+
+def get_edit_url(model, object_id):
+    """Get admin edit URL to an object of a model registered in ModelAdmin"""
+
+    url_name = AdminURLHelper(model).get_action_url_name('edit')
+    try:
+        return reverse(url_name, args=[object_id])
+    except NoReverseMatch:
+        return None

--- a/modeladminutils/static/modeladminutils/js/adminmodel-chooser.js
+++ b/modeladminutils/static/modeladminutils/js/adminmodel-chooser.js
@@ -1,4 +1,4 @@
-function createGenericModelChooser(id, modelString) {
+function createAdminModelChooser(id, modelString) {
     var chooserElement = $('#' + id + '-chooser');
     var docTitle = chooserElement.find('.title');
     var input = $('#' + id);
@@ -6,13 +6,13 @@ function createGenericModelChooser(id, modelString) {
 
     $('.action-choose', chooserElement).click(function() {
         ModalWorkflow({
-            url: window.chooserUrls.genericmodelChooser + modelString + '/',
+            url: window.chooserUrls.adminmodelChooser + modelString + '/',
             responses: {
-                genericmodelChosen: function(genericModelData) {
-                    input.val(genericModelData.id);
-                    docTitle.text(genericModelData.string);
+                adminmodelChosen: function(adminModelData) {
+                    input.val(adminModelData.id);
+                    docTitle.text(adminModelData.string);
                     chooserElement.removeClass('blank');
-                    editLink.attr('href', genericModelData.edit_link);
+                    editLink.attr('href', adminModelData.edit_link);
                 }
             }
         });

--- a/modeladminutils/templates/modeladminutils/chooser/chooser.html
+++ b/modeladminutils/templates/modeladminutils/chooser/chooser.html
@@ -12,7 +12,7 @@
                 {% endfor %}
             </ul>
         </form>
-        <div id="genericmodel-results">
+        <div id="adminmodel-results">
             {% include "modeladminutils/chooser/results.html" %}
         </div>
     </section>

--- a/modeladminutils/templates/modeladminutils/chooser/chooser.js
+++ b/modeladminutils/templates/modeladminutils/chooser/chooser.js
@@ -20,8 +20,8 @@ function(modal) {
             url: searchUrl,
             data: requestData,
             success: function(data, status) {
-                $('#genericmodel-results').html(data);
-                ajaxifyLinks($('#genericmodel-results'));
+                $('#adminmodel-results').html(data);
+                ajaxifyLinks($('#adminmodel-results'));
             }
         });
     }

--- a/modeladminutils/templates/modeladminutils/chooser/chosen.js
+++ b/modeladminutils/templates/modeladminutils/chooser/chosen.js
@@ -1,4 +1,4 @@
 function(modal) {
-    modal.respond('genericmodelChosen', {{ genericmodel_json|safe }});
+    modal.respond('adminmodelChosen', {{ adminmodel_json|safe }});
     modal.close();
 }

--- a/modeladminutils/templates/modeladminutils/widgets/adminmodel_chooser.html
+++ b/modeladminutils/templates/modeladminutils/widgets/adminmodel_chooser.html
@@ -1,6 +1,6 @@
 {% extends "wagtailadmin/widgets/chooser.html" %}
 
-{% block chooser_class %}genericmodel-chooser{% endblock %}
+{% block chooser_class %}adminmodel-chooser{% endblock %}
 
 {% block chosen_state_view %}
 <span class="title">{{ item }}</span>

--- a/modeladminutils/templates/modeladminutils/widgets/genericmodel_chooser.html
+++ b/modeladminutils/templates/modeladminutils/widgets/genericmodel_chooser.html
@@ -6,4 +6,4 @@
 <span class="title">{{ item }}</span>
 {% endblock %}
 
-{% block edit_chosen_item_url %}{{ edit_url }}{% endblock %}
+{% block edit_chosen_item_url %}{{ edit_link }}{% endblock %}

--- a/modeladminutils/views/chooser.py
+++ b/modeladminutils/views/chooser.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, unicode_literals
 import json
 
 from django.apps import apps
-from django.core.urlresolvers import NoReverseMatch, reverse
 from django.http import Http404
 from django.shortcuts import get_object_or_404, render
 from django.utils.six import text_type
@@ -11,7 +10,8 @@ from django.utils.six import text_type
 from wagtail.utils.pagination import paginate
 from wagtail.wagtailadmin.forms import SearchForm
 from wagtail.wagtailadmin.modal_workflow import render_modal_workflow
-from wagtail.contrib.modeladmin.helpers import AdminURLHelper
+
+from modeladminutils.helpers import get_edit_url
 
 
 def get_model_or_404(app_label, model_name):
@@ -76,16 +76,10 @@ def chosen(request, app_label, model_name, id):
     model = get_model_or_404(app_label, model_name)
     obj = get_object_or_404(model, id=id)
 
-    url_name = AdminURLHelper(model).get_action_url_name('edit')
-    try:
-        edit_link = reverse(url_name, args=[obj.id])
-    except NoReverseMatch:
-        edit_link = ''
-
     adminmodel_json = json.dumps({
         'id': obj.id,
         'string': text_type(obj),
-        'edit_link': edit_link,
+        'edit_link': get_edit_url(model, obj.id),
     })
 
     return render_modal_workflow(

--- a/modeladminutils/views/chooser.py
+++ b/modeladminutils/views/chooser.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, unicode_literals
 import json
 
 from django.apps import apps
+from django.core.urlresolvers import NoReverseMatch, reverse
 from django.http import Http404
 from django.shortcuts import get_object_or_404, render
 from django.utils.six import text_type
@@ -10,6 +11,7 @@ from django.utils.six import text_type
 from wagtail.utils.pagination import paginate
 from wagtail.wagtailadmin.forms import SearchForm
 from wagtail.wagtailadmin.modal_workflow import render_modal_workflow
+from wagtail.contrib.modeladmin.helpers import AdminURLHelper
 
 
 def get_model_or_404(app_label, model_name):
@@ -74,10 +76,16 @@ def chosen(request, app_label, model_name, id):
     model = get_model_or_404(app_label, model_name)
     obj = get_object_or_404(model, id=id)
 
+    url_name = AdminURLHelper(model).get_action_url_name('edit')
+    try:
+        edit_link = reverse(url_name, args=[obj.id])
+    except NoReverseMatch:
+        edit_link = ''
+
     genericmodel_json = json.dumps({
         'id': obj.id,
         'string': text_type(obj),
-        'edit_link': '',  # TODO: add edit link
+        'edit_link': edit_link,
     })
 
     return render_modal_workflow(

--- a/modeladminutils/views/chooser.py
+++ b/modeladminutils/views/chooser.py
@@ -82,7 +82,7 @@ def chosen(request, app_label, model_name, id):
     except NoReverseMatch:
         edit_link = ''
 
-    genericmodel_json = json.dumps({
+    adminmodel_json = json.dumps({
         'id': obj.id,
         'string': text_type(obj),
         'edit_link': edit_link,
@@ -92,6 +92,6 @@ def chosen(request, app_label, model_name, id):
         request,
         None, 'modeladminutils/chooser/chosen.js',
         {
-            'genericmodel_json': genericmodel_json,
+            'adminmodel_json': adminmodel_json,
         }
     )

--- a/modeladminutils/wagtail_hooks.py
+++ b/modeladminutils/wagtail_hooks.py
@@ -11,9 +11,9 @@ from modeladminutils import admin_urls
 @hooks.register('register_admin_urls')
 def register_admin_urls():
     return [
-        url(r'^genericmodel/', include(admin_urls,
-                                       namespace='modeladminutils',
-                                       app_name='modeladminutils')),
+        url(r'^adminmodel/', include(admin_urls,
+                                     namespace='modeladminutils',
+                                     app_name='modeladminutils')),
     ]
 
 
@@ -22,8 +22,8 @@ def editor_js():
     return format_html(
         """
             <script src="{0}"></script>
-            <script>window.chooserUrls.genericmodelChooser = '{1}';</script>
+            <script>window.chooserUrls.adminmodelChooser = '{1}';</script>
         """,
-        static('modeladminutils/js/genericmodel-chooser.js'),
-        urlresolvers.reverse('modeladminutils:choose_generic')
+        static('modeladminutils/js/adminmodel-chooser.js'),
+        urlresolvers.reverse('modeladminutils:choose_adminmodel')
     )

--- a/modeladminutils/widgets.py
+++ b/modeladminutils/widgets.py
@@ -2,33 +2,34 @@ from __future__ import absolute_import, unicode_literals
 
 import json
 
-from django.core.urlresolvers import NoReverseMatch, reverse
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext_lazy as _
 
 from wagtail.wagtailadmin.widgets import AdminChooser
 from wagtail.contrib.modeladmin.helpers import AdminURLHelper
 
+from modeladminutils.helpers import get_edit_url
+
 
 class AdminModelChooser(AdminChooser):
 
-    def __init__(self, model, url_helper_class=None, **kwargs):
+    def __init__(self, model, **kwargs):
         self.target_model = model
         name = self.target_model._meta.verbose_name
         self.choose_one_text = _('Choose %s') % name
         self.choose_another_text = _('Choose another %s') % name
         self.link_to_chosen_text = _('Edit this %s') % name
 
-        url_helper_class = url_helper_class or AdminURLHelper
-        self.url_helper = url_helper_class(model)
+        self.url_helper = AdminURLHelper(model)
 
         super(AdminModelChooser, self).__init__(**kwargs)
 
     def render_html(self, name, value, attrs):
-        instance, value = self.get_instance_and_id(self.target_model, value)
+        obj, value = self.get_instance_and_id(self.target_model, value)
 
         super_self = super(AdminModelChooser, self)
         original_field_html = super_self.render_html(name, value, attrs)
+        edit_link = get_edit_url(self.target_model, obj.id) if obj else None
 
         return render_to_string(
             "modeladminutils/widgets/adminmodel_chooser.html",
@@ -38,8 +39,8 @@ class AdminModelChooser(AdminChooser):
                 'original_field_html': original_field_html,
                 'attrs': attrs,
                 'value': value,
-                'item': instance,
-                'edit_link': self._get_edit_url(instance),
+                'item': obj,
+                'edit_link': edit_link,
             }
         )
 
@@ -51,13 +52,3 @@ class AdminModelChooser(AdminChooser):
             model=json.dumps('{app}/{model}'.format(
                 app=model._meta.app_label,
                 model=model._meta.model_name)))
-
-    def _get_edit_url(self, instance):
-        if instance is None:
-            return None
-
-        url_name = self.url_helper.get_action_url_name('edit')
-        try:
-            return reverse(url_name, args=[instance.id])
-        except NoReverseMatch:
-            return None

--- a/modeladminutils/widgets.py
+++ b/modeladminutils/widgets.py
@@ -10,7 +10,7 @@ from wagtail.wagtailadmin.widgets import AdminChooser
 from wagtail.contrib.modeladmin.helpers import AdminURLHelper
 
 
-class GenericModelChooser(AdminChooser):
+class AdminModelChooser(AdminChooser):
 
     def __init__(self, model, url_helper_class=None, **kwargs):
         self.target_model = model
@@ -22,16 +22,16 @@ class GenericModelChooser(AdminChooser):
         url_helper_class = url_helper_class or AdminURLHelper
         self.url_helper = url_helper_class(model)
 
-        super(GenericModelChooser, self).__init__(**kwargs)
+        super(AdminModelChooser, self).__init__(**kwargs)
 
     def render_html(self, name, value, attrs):
         instance, value = self.get_instance_and_id(self.target_model, value)
 
-        super_self = super(GenericModelChooser, self)
+        super_self = super(AdminModelChooser, self)
         original_field_html = super_self.render_html(name, value, attrs)
 
         return render_to_string(
-            "modeladminutils/widgets/genericmodel_chooser.html",
+            "modeladminutils/widgets/adminmodel_chooser.html",
             {
                 'widget': self,
                 'model_opts': self.target_model._meta,
@@ -46,7 +46,7 @@ class GenericModelChooser(AdminChooser):
     def render_js_init(self, id_, name, value):
         model = self.target_model
 
-        return "createGenericModelChooser({id}, {model});".format(
+        return "createAdminModelChooser({id}, {model});".format(
             id=json.dumps(id_),
             model=json.dumps('{app}/{model}'.format(
                 app=model._meta.app_label,

--- a/modeladminutils/widgets.py
+++ b/modeladminutils/widgets.py
@@ -39,7 +39,7 @@ class GenericModelChooser(AdminChooser):
                 'attrs': attrs,
                 'value': value,
                 'item': instance,
-                'edit_url_name': self._get_edit_url(instance),
+                'edit_link': self._get_edit_url(instance),
             }
         )
 
@@ -53,6 +53,9 @@ class GenericModelChooser(AdminChooser):
                 model=model._meta.model_name)))
 
     def _get_edit_url(self, instance):
+        if instance is None:
+            return None
+
         url_name = self.url_helper.get_action_url_name('edit')
         try:
             return reverse(url_name, args=[instance.id])

--- a/tests/test_modeladminutils/test_edit_handlers.py
+++ b/tests/test_modeladminutils/test_edit_handlers.py
@@ -3,10 +3,10 @@ from wagtail.tests.testapp.models import PageChooserModel
 from wagtail.wagtailadmin.edit_handlers import ObjectList
 from wagtail.wagtailcore.models import Page
 
-from modeladminutils.edit_handlers import GenericModelChooserPanel
+from modeladminutils.edit_handlers import AdminModelChooserPanel
 
 
-class TestGenericModelChooserPanel(object):
+class TestAdminModelChooserPanel(object):
     @pytest.fixture
     def model(self):
         """A model with a foreign key to Page
@@ -16,10 +16,10 @@ class TestGenericModelChooserPanel(object):
 
     @pytest.fixture
     def edit_handler_class(self, model):
-        """A GenericModelChooserPanel class that works on
+        """A AdminModelChooserPanel class that works on
         PageChooserModel's 'page' field
         """
-        object_list = ObjectList([GenericModelChooserPanel('page')])
+        object_list = ObjectList([AdminModelChooserPanel('page')])
         return object_list.bind_to_model(model)
 
     @pytest.fixture
@@ -67,10 +67,10 @@ class TestGenericModelChooserPanel(object):
             'value="%s" />' % test_page.id
         )
         assert input_html in field_html
-        # and createGenericModelChooser script is in the field HTML
+        # and createAdminModelChooser script is in the field HTML
         script_html = (
             '<script>'
-            'createGenericModelChooser("id_page", "wagtailcore/page");'
+            'createAdminModelChooser("id_page", "wagtailcore/page");'
             '</script>'
         )
         assert script_html in field_html


### PR DESCRIPTION
I was trying to fix some bugs with edit link in `GenericModelChooser` (27b5619). It became clear that we were not able to override url helper class (so we couldn't call the chooser generic - it was tightly coupled with AdminUrlHelper). That's why I decided to also rename the chooser into `AdminModelChooser` in subsequent commits.

Logistics:

* 27b5619 only fixes bugs
* cb1f5f3 only renames things
* 1d89463 changes the way we get edit link