### PR TITLE
Add `git fetch --unshallow` to before_deploy in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ script:
 before_deploy:
   - sudo apt-get update
   - sudo apt-get install docker-engine
+  - git fetch --unshallow
 deploy:
   - provider: script
     script: ./scripts/push_image.sh


### PR DESCRIPTION
Travis downloads only 50 recent commits (which is known as shallow copy) by default:
```
git clone --depth=50 https://github.com/kinaklub/next.filmfest.by.git kinaklub/next.filmfest.by
```

It makes sense for PR checks because `clone` process is faster on big
repositories. However it can break one of the commands we use for
deployment:
```
git describe --tags
```

The command above expects to have at least one tag in the downloaded
commits to produce a version like `0.3` for tag 0.3 or
`0.3-273-gc479fe0` for an untagged revision with hash `gc479fe0` that
is 273 commits forward from tag `0.3`.

So let's try to unshallow (download the full history) the repository
if we are going to deploy this version to production.

An alternative approach for fixing this is to add parameter `--always`
to return just the commit hash if there are no tags in the recent
commits:

```
$ git describe --tags --always
c479fe0
```