### PR TITLE
Change the way we unshallow repo in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ script:
 before_deploy:
   - sudo apt-get update
   - sudo apt-get install docker-engine
-  - git fetch --unshallow
+  - git fetch --depth=2147483647
 deploy:
   - provider: script
     script: ./scripts/push_image.sh


### PR DESCRIPTION
In e17864c we introduced repo unshallowing. Unfortunately it didn't
work on Travis, see [Build #544][1]:
```
$ git fetch --unshallow

fatal: --unshallow on a complete repository does not make sense
```

Let's try to do the same with `--depth` parameter as suggested in
the [commit to git that adds unsahllow][2].

[1]: https://travis-ci.org/kinaklub/next.filmfest.by/builds/211619581
[2]: https://github.com/git/git/commit/4dcb167fc3536db0e78c50f239cd3a19afd383fa