### PR TITLE
Add default superuser for development environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,38 +154,27 @@ PR review process:
 
 4. Give postgres 20-30 seconds to initialize
 
-4. Create a local user:
-
-    ```
-    docker-compose run web createsuperuser
-    ```
-
-5. Visit http://127.0.0.1:8000/ in your web browser
+5. Visit http://127.0.0.1:8000/ in your web browser, superuser
+   `admin:111111` should have already been created.
 
 ### Recreating development environment
 
 If one wants to recreate their development environment from scratch
 and one doesn't care about the existing data in database, one needs to:
 
-1. stop all the containers:
+1. remove all the containers, purge all the data:
 
     ```
-    docker-compose stop
+    docker-compose down
     ```
 
-2. remove containers
-
-    ```
-    docker-compose rm -r
-    ```
-
-3. rebuild images
+2. rebuild images
 
     ```
     docker-compose build
     ```
 
-4. use quickstart guide above for setting up the development environment
+3. use quickstart guide above for setting up the development environment
 
 ### Testing code
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
     command: launch :8000
     environment:
       DJANGO_SETTINGS_MODULE: filmfest.settings.docker
+      DJANGO_ADMIN_USERNAME: admin
+      DJANGO_ADMIN_PASSWORD: 111111
     volumes:
       - .:/app/src
       - web_media:/app/media

--- a/results/migrations/0017_add_films_2012_data.py
+++ b/results/migrations/0017_add_films_2012_data.py
@@ -93,7 +93,6 @@ def create_film_pages(apps):
         frame.save()
 
         slug = slugify(item['film_title_en'])
-        print slug
         title = item['film_title_en']
         page = add_subpage(
             parent=filmsindex_page,


### PR DESCRIPTION
Me and @davojta have recently discovered that it's very convenient to recreate data volumes when switching between bracnhes with:
```
docker-compose down
docker-compose up
```
(otherwise unmerged Page classes under development can break the application)

But one always needs to recreate local admin user after running `docker-compose down`, which slightly slows us down. This PR adds default superuser `admin:111111` that can be used for development.

We'll also be able to reuse it for UI E2E tests on production later.