### PR TITLE
Fix production deploy

### DIFF
--- a/events/migrations/0004_timetable_2017.py
+++ b/events/migrations/0004_timetable_2017.py
@@ -5,6 +5,7 @@ import json
 import os
 
 from dateutil.parser import parse as parse_datetime
+from django.conf import settings
 from django.db import migrations
 
 from cpm_generic.migration_utils import (add_subpage, get_content_type,
@@ -127,8 +128,12 @@ class Migration(migrations.Migration):
         ('home', '0002_create_homepage'),
     ]
 
-    operations = [
-        migrations.RunPython(add_filmprograms_2017, remove_filmprograms_2017),
-        migrations.RunPython(add_venues_2017, remove_venues_2017),
-        migrations.RunPython(add_timetable_2017, remove_timetable_2017),
-    ]
+    if settings.DEVELOPMENT:
+        operations = [
+            migrations.RunPython(add_filmprograms_2017,
+                                 remove_filmprograms_2017),
+            migrations.RunPython(add_venues_2017, remove_venues_2017),
+            migrations.RunPython(add_timetable_2017, remove_timetable_2017),
+        ]
+    else:
+        operations = []

--- a/filmfest/settings/base.py
+++ b/filmfest/settings/base.py
@@ -18,6 +18,7 @@ PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BASE_DIR = os.path.dirname(PROJECT_DIR)
 
 STACK_PREFIX = os.environ.get('STACK_PREFIX', '')
+DEVELOPMENT = True
 
 
 # Quick-start development settings - unsuitable for production

--- a/filmfest/settings/prod.py
+++ b/filmfest/settings/prod.py
@@ -12,6 +12,7 @@ DATABASES = {
 }
 
 DEBUG = False
+DEVELOPMENT = False
 TEMPLATE_DEBUG = False
 SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY', 'secret')  # noqa: F405
 ALLOWED_HOSTS = (

--- a/results/migrations/0018_add_partners_2012_data.py
+++ b/results/migrations/0018_add_partners_2012_data.py
@@ -84,7 +84,6 @@ def create_partner_pages(apps):
         image.save()
 
         slug = slugify(item['id'])
-        print slug
         title = item['name_en']
         page = add_subpage(
             parent=parnerindex_page,


### PR DESCRIPTION
We can't update production at the moment:

```
Traceback (most recent call last):
  File "manage.py", line 144, in <module>
    main()
  File "manage.py", line 140, in main
    return handler(args, settings_module)
  File "manage.py", line 87, in launch
    execute_from_command_line(['manage.py', 'migrate', '--noinput'])
  File "/app/lib/python2.7/site-packages/django/core/management/__init__.py", line 353, in execute_from_command_line
    utility.execute()
  File "/app/lib/python2.7/site-packages/django/core/management/__init__.py", line 345, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/app/lib/python2.7/site-packages/django/core/management/base.py", line 348, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/app/lib/python2.7/site-packages/django/core/management/base.py", line 399, in execute
    output = self.handle(*args, **options)
  File "/app/lib/python2.7/site-packages/django/core/management/commands/migrate.py", line 200, in handle
    executor.migrate(targets, plan, fake=fake, fake_initial=fake_initial)
  File "/app/lib/python2.7/site-packages/django/db/migrations/executor.py", line 92, in migrate
    self._migrate_all_forwards(plan, full_plan, fake=fake, fake_initial=fake_initial)
  File "/app/lib/python2.7/site-packages/django/db/migrations/executor.py", line 121, in _migrate_all_forwards
    state = self.apply_migration(state, migration, fake=fake, fake_initial=fake_initial)
  File "/app/lib/python2.7/site-packages/django/db/migrations/executor.py", line 198, in apply_migration
    state = migration.apply(state, schema_editor)
  File "/app/lib/python2.7/site-packages/django/db/migrations/migration.py", line 123, in apply
    operation.database_forwards(self.app_label, schema_editor, old_state, project_state)
  File "/app/lib/python2.7/site-packages/django/db/migrations/operations/special.py", line 183, in database_forwards
    self.code(from_state.apps, schema_editor)
  File "/app/src/events/migrations/0004_timetable_2017.py", line 37, in add_filmprograms_2017
    **item
  File "/app/src/cpm_generic/migration_utils.py", line 12, in add_subpage
    max_subpath = 0 if max_sibling is None else int(max_sibling.path[-4:])
ValueError: invalid literal for int() with base 10: '000J'
```

* 27b9a8a fixes the migration
*  fe9cb46 makes sure we actually skip it