### PR TITLE
Use absolute URLs in timetable template

### DIFF
--- a/events/templates/events/time_table.html
+++ b/events/templates/events/time_table.html
@@ -13,7 +13,7 @@
         <dt>{{ event.starts_at|date:"H:i" }}</dt>
         <dd>
           {% if event.program.live %}
-          <a href="{% pageurl event.program %}">{{ event.program.name }}</a>
+          <a href="{{ request.scheme }}://{{ request.get_host }}{% pageurl event.program %}">{{ event.program.name }}</a>
           {% else %}
           {{ event.program.name }}
           {% endif %}


### PR DESCRIPTION
We reuse this page in legacy filmfest.by website by injecting HTML, so
we need to have absolute URLs.