### PR TITLE
Update wagtail-pg-search-backend to 1.3.2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@ djangorestframework==3.4.0
 pycountry==0.14.2
 python-dateutil==2.6.0
 wagtail==1.9
-wagtail-pg-search-backend==1.3.0
+wagtail-pg-search-backend==1.3.2
 
 # dependencies
 beautifulsoup4==4.5.3


### PR DESCRIPTION
We hope [this commit](https://github.com/wagtail/wagtail-pg-search-backend/commit/9ae0fbbda4c675c9a3ff0b450357c38a51f89ca3) will fix the bug we've seen in production.

```
default: Rebuilding index cpm_data.Filma
default: cpm_data.Film             .
default: indexed 78 objects

default: Rebuilding index cpm_generic.IndexPage
Traceback (most recent call last):
  File "manage.py", line 121, in <module>
    main()
  File "manage.py", line 117, in main
    return handler(args, settings_module)
  File "manage.py", line 66, in launch
    execute_from_command_line(['manage.py', 'update_index'])
  File "/app/lib/python2.7/site-packages/django/core/management/__init__.py", line 367, in execute_from_command_line
    utility.execute()
  File "/app/lib/python2.7/site-packages/django/core/management/__init__.py", line 359, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/app/lib/python2.7/site-packages/django/core/management/base.py", line 294, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/app/lib/python2.7/site-packages/django/core/management/base.py", line 345, in execute
    output = self.handle(*args, **options)
  File "/app/lib/python2.7/site-packages/wagtail/wagtailsearch/management/commands/update_index.py", line 120, in handle
    self.update_backend(backend_name, schema_only=options.get('schema_only', False))
  File "/app/lib/python2.7/site-packages/wagtail/wagtailsearch/management/commands/update_index.py", line 73, in update_backend
    index = rebuilder.start()
  File "/app/lib/python2.7/site-packages/wagtail_pgsearchbackend/backend.py", line 299, in start
    self.index.delete_stale_entries()
  File "/app/lib/python2.7/site-packages/wagtail_pgsearchbackend/backend.py", line 75, in delete_stale_entries
    % (IndexEntry._meta.db_table, pks_sql), params)
  File "/app/lib/python2.7/site-packages/django/db/backends/utils.py", line 64, in execute
    return self.cursor.execute(sql, params)
  File "/app/lib/python2.7/site-packages/django/db/utils.py", line 94, in __exit__
    six.reraise(dj_exc_type, dj_exc_value, traceback)
  File "/app/lib/python2.7/site-packages/django/db/backends/utils.py", line 64, in execute
    return self.cursor.execute(sql, params)
django.db.utils.ProgrammingError: operator does not exist: text = integer
LINE 1: ...agtail_pgsearchbackend_indexentry WHERE object_id IN ((SELEC...
                                                             ^
HINT:  No operator matches the given name and argument type(s). You might need to add explicit type casts.
```
                                                _