### PR TITLE
Add logos to bump CI in 2020

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # next.filmfest.by
 
-[![Travis](https://img.shields.io/travis/kinaklub/next.filmfest.by/master.svg)](https://travis-ci.org/kinaklub/next.filmfest.by)
-[![AppVeyor](https://img.shields.io/appveyor/ci/nott/next-filmfest-by/master.svg)](https://ci.appveyor.com/project/nott/next-filmfest-by/history)
+[![Travis](https://img.shields.io/travis/kinaklub/next.filmfest.by/master.svg?logo=travis)](https://travis-ci.org/kinaklub/next.filmfest.by)
+[![AppVeyor](https://img.shields.io/appveyor/ci/nott/next-filmfest-by/master.svg?logo=appveyor)](https://ci.appveyor.com/project/nott/next-filmfest-by/history)
 [![Netlify static preview](https://img.shields.io/badge/preview-ready-brightgreen.svg)](https://filmfest.netlify.com/)
 
 Welcome to the workplace for upcoming website for Cinema Perpetuum


### PR DESCRIPTION
I'm getting weekly security warnings in my inbox and AppVeyor CI in branches is broken after 3 years of bitrotting.

https://ci.appveyor.com/project/nott/next-filmfest-by/builds/30737167

Need to merge this request to see if the same error will trigger in `master`.