### PR TITLE
Switch to Python 3

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -9,6 +9,9 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
     - name: install
       run: python -m pip install tox
     - name: build

--- a/requirements/_pytest.txt
+++ b/requirements/_pytest.txt
@@ -1,7 +1,7 @@
 # consciously added packages
 flake8-debugger==1.4.0
 flake8-print==2.0.2
-pytest==2.9.2
+pytest==6.2.2
 pytest-django==2.9.1
 pytest-jsonlint==0.0.1
 pytest-flake8==0.6
@@ -12,6 +12,5 @@ demjson==2.2.4
 enum34==1.1.6
 flake8==3.0.4
 mccabe==0.5.0
-py==1.4.31
 pycodestyle==2.0.0
 pyflakes==1.2.3

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,10 +1,9 @@
 # consciously added packages
-Django==1.10.8
+Django==1.11.*
 djangorestframework==3.4.0
 pycountry==0.14.2
 python-dateutil==2.6.0
-wagtail==1.9
-wagtail-pg-search-backend==1.3.2
+wagtail==1.10.*
 
 # dependencies
 beautifulsoup4==4.5.3
@@ -12,7 +11,7 @@ django-modelcluster==3.1
 django-taggit==0.22.0
 django-treebeard==4.0.1
 html5lib==0.999999999
-Pillow==3.4.2
+Pillow==8.1.2
 pytz==2016.6.1
 requests==2.25.1
 six==1.10.0

--- a/scripts/netlify.sh
+++ b/scripts/netlify.sh
@@ -12,21 +12,23 @@
 # Script should complete in 15 minutes.
 #
 
+set -x  # print lines being executed
+set -e  # exit on first error
+
 ROOTDIR=$(dirname $(dirname $0))
 cd $ROOTDIR
 
-echo --- [bootstrap] creating virtualenv in .v
-virtualenv .v
-.v/bin/pip install -r requirements/base.txt
+echo --- [bootstrap] installing dependencies
+pip install -r requirements/base.txt
 
 echo --- [bootstrap] running migrations
 # switch back from dev config to base
 export DJANGO_SETTINGS_MODULE=filmfest.settings.netlify
 export PYTHONUNBUFFERED=1
-.v/bin/python manage.py migrate
+python manage.py migrate
 
 echo --- [bootstrap] starting server in background
-.v/bin/python manage.py runserver 127.0.0.1:8000 --insecure &
+python manage.py runserver 127.0.0.1:8000 --insecure &
 sleep 5
 
 echo --- [bootstrap] grabbing site copy
@@ -43,4 +45,4 @@ pkill -f manage.py
 # returns 0, but we can also check wget exit code or
 # log for 404 errors to fail build if there are any
 
-exit 0
+#exit 0

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27-sqlite
+envlist = py-sqlite
 skipsdist=true
 
 [testenv]


### PR DESCRIPTION
Python 2 is phased out.

Originally I wanted to get back Netlify previews, and in the process noticed that GitHub Actions tests are using Python 2.